### PR TITLE
feat: remove manual refit param

### DIFF
--- a/examples/configs/grpo-deepscaler-1.5b-8K.yaml
+++ b/examples/configs/grpo-deepscaler-1.5b-8K.yaml
@@ -42,7 +42,6 @@ policy:
   precision: "bfloat16"
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4 # used for refitting inference engine, the unit is GB
 
   dtensor_cfg:
     enabled: true

--- a/examples/configs/grpo_math_1B.yaml
+++ b/examples/configs/grpo_math_1B.yaml
@@ -42,7 +42,6 @@ policy:
   precision: "bfloat16"
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4 # used for refitting inference engine, the unit is GB
 
   dtensor_cfg:
     enabled: true

--- a/examples/configs/grpo_math_8B.yaml
+++ b/examples/configs/grpo_math_8B.yaml
@@ -17,7 +17,6 @@ policy:
   precision: "bfloat16"
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4 # used for refitting inference engine, the unit is GB
 
   dtensor_cfg:
     enabled: True

--- a/examples/configs/recipes/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1.yaml
+++ b/examples/configs/recipes/llm/grpo-gemma3-1b-it-1n8g-fsdp2tp1.yaml
@@ -36,7 +36,6 @@ policy:
   precision: bfloat16
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4
   dtensor_cfg:
     enabled: true
     cpu_offload: false

--- a/examples/configs/recipes/llm/grpo-gemma3-27b-it-16n8g-fsdp2tp8sp-actckpt-long.yaml
+++ b/examples/configs/recipes/llm/grpo-gemma3-27b-it-16n8g-fsdp2tp8sp-actckpt-long.yaml
@@ -36,7 +36,6 @@ policy:
   precision: bfloat16
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4
   dtensor_cfg:
     enabled: true
     cpu_offload: false

--- a/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.1-8b-instruct-4n8g-fsdp2tp1-long.v3.yaml
@@ -36,7 +36,6 @@ policy:
   precision: bfloat16
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4
   dtensor_cfg:
     enabled: true
     cpu_offload: false

--- a/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-llama3.2-1b-instruct-1n8g-fsdp2tp1.v3.yaml
@@ -36,7 +36,6 @@ policy:
   precision: bfloat16
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4
   dtensor_cfg:
     enabled: true
     cpu_offload: false

--- a/examples/configs/recipes/llm/grpo-qwen2.5-32b-16n8g-fsdp2tp8sp-actckpt-long.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-32b-16n8g-fsdp2tp8sp-actckpt-long.v3.yaml
@@ -36,7 +36,6 @@ policy:
   precision: bfloat16
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4
   dtensor_cfg:
     enabled: true
     cpu_offload: false

--- a/examples/configs/recipes/llm/grpo-qwen2.5-32b-16n8g-fsdp2tp8sp-actckpt.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-32b-16n8g-fsdp2tp8sp-actckpt.v3.yaml
@@ -36,7 +36,6 @@ policy:
   precision: bfloat16
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4
   dtensor_cfg:
     enabled: true
     cpu_offload: false

--- a/examples/configs/recipes/llm/grpo-qwen2.5-7b-instruct-4n8g-fsdp1.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-7b-instruct-4n8g-fsdp1.v3.yaml
@@ -36,7 +36,6 @@ policy:
   precision: bfloat16
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4
   dtensor_cfg:
     enabled: false
     cpu_offload: false

--- a/examples/configs/recipes/llm/grpo-qwen2.5-7b-instruct-4n8g-fsdp2tp4sp.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-7b-instruct-4n8g-fsdp2tp4sp.v3.yaml
@@ -36,7 +36,6 @@ policy:
   precision: bfloat16
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4
   dtensor_cfg:
     enabled: true
     cpu_offload: false

--- a/examples/configs/recipes/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3.yaml
+++ b/examples/configs/recipes/llm/grpo-qwen2.5-math-1.5b-instruct-1n8g-fsdp2tp1.v3.yaml
@@ -36,7 +36,6 @@ policy:
   precision: bfloat16
   fsdp_offload_enabled: false
   activation_checkpointing_enabled: false
-  refit_buffer_size_gb: 4
   dtensor_cfg:
     enabled: true
     cpu_offload: false

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -286,7 +286,7 @@ def setup(
 def refit_policy_generation(
     policy: ColocatablePolicyInterface,
     policy_generation: GenerationInterface,
-    refit_buffer_size_gb: int = None,
+    refit_buffer_size_gb: Optional[int] = None,
 ) -> None:
     """Refit the policy generation interface with the latest policy weights.
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -286,7 +286,7 @@ def setup(
 def refit_policy_generation(
     policy: ColocatablePolicyInterface,
     policy_generation: GenerationInterface,
-    refit_buffer_size_gb: int,  # GB
+    refit_buffer_size_gb: int = 10,  # GB
 ) -> None:
     """Refit the policy generation interface with the latest policy weights."""
     policy.offload_before_refit()
@@ -357,13 +357,12 @@ def grpo_train(
     consumed_samples = grpo_save_state["consumed_samples"]
     val_period = master_config["grpo"]["val_period"]
     val_at_start = master_config["grpo"]["val_at_start"]
-    refit_buffer_size_gb = master_config["policy"]["refit_buffer_size_gb"]
 
     # Run validation at the start if configured
     if val_at_start and step == 0:
         print("\n🔍 Running initial validation...")
         if NEED_REFIT and POLICY_GENERATION_STALE:
-            refit_policy_generation(policy, policy_generation, refit_buffer_size_gb)
+            refit_policy_generation(policy, policy_generation)
             POLICY_GENERATION_STALE = False
         else:
             policy_generation.prepare_for_generation()
@@ -406,11 +405,7 @@ def grpo_train(
             print(f"▶ Generating responses for batch of size {repeated_batch.size}...")
             with timer.time("prepare_for_generation"):
                 if NEED_REFIT and POLICY_GENERATION_STALE:
-                    refit_policy_generation(
-                        policy,
-                        policy_generation,
-                        refit_buffer_size_gb,
-                    )
+                    refit_policy_generation(policy, policy_generation)
                     POLICY_GENERATION_STALE = False
                 else:
                     policy_generation.prepare_for_generation()
@@ -522,11 +517,7 @@ def grpo_train(
             # Run validation if it's a validation step
             if is_last_step or (val_period > 0 and (step + 1) % val_period == 0):
                 if NEED_REFIT and POLICY_GENERATION_STALE:
-                    refit_policy_generation(
-                        policy,
-                        policy_generation,
-                        refit_buffer_size_gb,
-                    )
+                    refit_policy_generation(policy, policy_generation)
                     POLICY_GENERATION_STALE = False
                 else:
                     policy_generation.prepare_for_generation()

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -286,20 +286,22 @@ def setup(
 def refit_policy_generation(
     policy: ColocatablePolicyInterface,
     policy_generation: GenerationInterface,
-    refit_buffer_size_gb: Optional[int] = None,
+    _refit_buffer_size_gb: Optional[int] = None,
 ) -> None:
     """Refit the policy generation interface with the latest policy weights.
 
     Args:
         policy: The policy to provide weights to the inference engine.
         policy_generation: The inference engine to refit.
-        refit_buffer_size_gb: The size of the buffer to use for refitting. If None, will compute by the remaining memory.
+        _refit_buffer_size_gb: The size of the buffer to use for refitting.
+            If it is None, the buffer size will be computed by the remaining memory.
+            This parameter is primarily used for testing.
     """
     policy.offload_before_refit()
     policy_generation.prepare_for_generation(tags=["weights"])
     # get model param keys, which is grouped by size
     grouped_param_keys = policy.prepare_weights_for_ipc(
-        refit_buffer_size_gb=refit_buffer_size_gb
+        _refit_buffer_size_gb=_refit_buffer_size_gb
     )
     # do update
     for keys in grouped_param_keys:

--- a/nemo_rl/models/policy/__init__.py
+++ b/nemo_rl/models/policy/__init__.py
@@ -75,7 +75,6 @@ class PolicyConfig(TypedDict):
     max_grad_norm: Optional[Union[float, int]]
     fsdp_offload_enabled: bool
     activation_checkpointing_enabled: bool
-    refit_buffer_size_gb: int
     optimizer: NotRequired[PytorchOptimizerConfig] = None
     scheduler: NotRequired[list[SinglePytorchSchedulerConfig] | SchedulerMilestones] = (
         None

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -679,7 +679,9 @@ class DTensorPolicyWorker:
         return get_device_uuid(device_idx)
 
     @torch.no_grad()
-    def prepare_weights_for_ipc(self, refit_buffer_size_gb: int = None) -> list[list[str]]:
+    def prepare_weights_for_ipc(
+        self, refit_buffer_size_gb: Optional[int] = None
+    ) -> list[list[str]]:
         """Prepare the weights for IPC.
 
         Returns:
@@ -693,7 +695,7 @@ class DTensorPolicyWorker:
 
         # Calculate available memory
         if refit_buffer_size_gb is not None:
-            total_available_bytes = refit_buffer_size_gb * (1024**3)
+            total_available_bytes: float = refit_buffer_size_gb * (1024**3)
         else:
             from nemo_rl.utils.nvml import get_free_memory_bytes
 
@@ -706,9 +708,10 @@ class DTensorPolicyWorker:
 
         # Group tensors by size
         cur_available_bytes = total_available_bytes
-        grouped_param_keys, keys = [], []
+        grouped_param_keys: list[list[str]] = []
+        keys: list[str] = []
 
-        for key, tensor in self._held_sharded_state_dict_reference.items():
+        for key, tensor in self._held_sharded_state_dict_reference.items():  # type: ignore
             # dtensor's numel will return complete tensor instead of only local tensor
             size_in_bytes = tensor.element_size() * tensor.numel()
 

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -679,18 +679,52 @@ class DTensorPolicyWorker:
         return get_device_uuid(device_idx)
 
     @torch.no_grad()
-    def prepare_weights_for_ipc(self) -> list[tuple[str, int]]:
+    def prepare_weights_for_ipc(self, refit_buffer_size_gb: int = None) -> list[list[str]]:
+        """Prepare the weights for IPC.
+
+        Returns:
+            list: A list containing the keys of the parameters, which is grouped by size.
+        """
+        # Get state_dict
         self.model = self.move_to_cuda(self.model)
         self._held_sharded_state_dict_reference: dict[str, torch.Tensor] = (
             self.model.state_dict()
         )
-        # Collect info for streaming multiple tensors
-        state_dict_info = []
-        for name, tensor in self._held_sharded_state_dict_reference.items():
+
+        # Calculate available memory
+        if refit_buffer_size_gb is not None:
+            total_available_bytes = refit_buffer_size_gb * (1024**3)
+        else:
+            from nemo_rl.utils.nvml import get_free_memory_bytes
+
+            # Get current device index from torch
+            device_idx = torch.cuda.current_device()
+            # Get device free memory using NVML
+            total_available_bytes = get_free_memory_bytes(device_idx)
+            # Use 80% of the free memory for safety
+            total_available_bytes *= 0.8
+
+        # Group tensors by size
+        cur_available_bytes = total_available_bytes
+        grouped_param_keys, keys = [], []
+
+        for key, tensor in self._held_sharded_state_dict_reference.items():
             # dtensor's numel will return complete tensor instead of only local tensor
             size_in_bytes = tensor.element_size() * tensor.numel()
-            state_dict_info.append((name, size_in_bytes))
-        return state_dict_info
+
+            if size_in_bytes > cur_available_bytes:
+                if keys:
+                    grouped_param_keys.append(keys)
+                    keys = []
+                cur_available_bytes = total_available_bytes
+
+            keys.append(key)
+            cur_available_bytes -= size_in_bytes
+
+        if keys:
+            grouped_param_keys.append(keys)
+
+        return grouped_param_keys
 
     @torch.no_grad()
     def get_weights_ipc_handles(self, keys: Iterable[str]) -> dict[str, Any]:

--- a/nemo_rl/models/policy/dtensor_policy_worker.py
+++ b/nemo_rl/models/policy/dtensor_policy_worker.py
@@ -700,6 +700,11 @@ class DTensorPolicyWorker:
             "prepare_weights_for_ipc must be called before get_weights_ipc_handles"
         )
 
+        # Clean up the held tensors to reduce peak memory
+        if self._held_streamed_param_reference is not None:
+            del self._held_streamed_param_reference
+            self._held_streamed_param_reference = None
+
         converted_params = {}
         for key in keys:
             # Get full_tensor for dtensor (GPU > 1)

--- a/nemo_rl/models/policy/fsdp1_policy_worker.py
+++ b/nemo_rl/models/policy/fsdp1_policy_worker.py
@@ -853,6 +853,11 @@ class FSDP1PolicyWorker:
             "prepare_weights_for_ipc must be called before get_weights_ipc_handles"
         )
 
+        # Clean up the held tensors to reduce peak memory
+        if self._held_streamed_param_reference is not None:
+            del self._held_streamed_param_reference
+            self._held_streamed_param_reference = None
+
         converted_params = {}
         for key in keys:
             # Get full_tensor for dtensor (GPU > 1)

--- a/nemo_rl/models/policy/fsdp1_policy_worker.py
+++ b/nemo_rl/models/policy/fsdp1_policy_worker.py
@@ -818,7 +818,12 @@ class FSDP1PolicyWorker:
         return get_device_uuid(device_idx)
 
     @torch.no_grad()
-    def prepare_weights_for_ipc(self) -> list[tuple[str, int]]:
+    def prepare_weights_for_ipc(self, refit_buffer_size_gb: int = None) -> list[list[str]]:
+        """Prepare the weights for IPC.
+
+        Returns:
+            list: A list containing the keys of the parameters, which is grouped by size.
+        """
         from torch.distributed.fsdp.api import ShardedStateDictConfig, StateDictType
 
         # If the model is not FSDP, then we need to manually move it to the GPU
@@ -835,14 +840,40 @@ class FSDP1PolicyWorker:
             ):
                 self._held_sharded_state_dict_reference = self.model.state_dict()
 
-        # Collect info for streaming multiple tensors
-        state_dict_info = []
-        for name, tensor in self._held_sharded_state_dict_reference.items():  # type: ignore
+        # Calculate available memory
+        if refit_buffer_size_gb is not None:
+            total_available_bytes = refit_buffer_size_gb * (1024**3)
+        else:
+            from nemo_rl.utils.nvml import get_free_memory_bytes
+
+            # Get current device index from torch
+            device_idx = torch.cuda.current_device()
+            # Get device free memory using NVML
+            total_available_bytes = get_free_memory_bytes(device_idx)
+            # Use 80% of the free memory for safety
+            total_available_bytes *= 0.8
+
+        # Group tensors by size
+        cur_available_bytes = total_available_bytes
+        grouped_param_keys, keys = [], []
+
+        for key, tensor in self._held_sharded_state_dict_reference.items():
             # dtensor's numel will return complete tensor instead of only local tensor
             size_in_bytes = tensor.element_size() * tensor.numel()
-            state_dict_info.append((name, size_in_bytes))
 
-        return state_dict_info
+            if size_in_bytes > cur_available_bytes:
+                if keys:
+                    grouped_param_keys.append(keys)
+                    keys = []
+                cur_available_bytes = total_available_bytes
+
+            keys.append(key)
+            cur_available_bytes -= size_in_bytes
+
+        if keys:
+            grouped_param_keys.append(keys)
+
+        return grouped_param_keys
 
     @torch.no_grad()
     def get_weights_ipc_handles(self, keys: list[str]) -> dict[str, Any]:

--- a/nemo_rl/models/policy/fsdp1_policy_worker.py
+++ b/nemo_rl/models/policy/fsdp1_policy_worker.py
@@ -818,7 +818,9 @@ class FSDP1PolicyWorker:
         return get_device_uuid(device_idx)
 
     @torch.no_grad()
-    def prepare_weights_for_ipc(self, refit_buffer_size_gb: int = None) -> list[list[str]]:
+    def prepare_weights_for_ipc(
+        self, refit_buffer_size_gb: Optional[int] = None
+    ) -> list[list[str]]:
         """Prepare the weights for IPC.
 
         Returns:
@@ -842,7 +844,7 @@ class FSDP1PolicyWorker:
 
         # Calculate available memory
         if refit_buffer_size_gb is not None:
-            total_available_bytes = refit_buffer_size_gb * (1024**3)
+            total_available_bytes: float = refit_buffer_size_gb * (1024**3)
         else:
             from nemo_rl.utils.nvml import get_free_memory_bytes
 
@@ -855,9 +857,10 @@ class FSDP1PolicyWorker:
 
         # Group tensors by size
         cur_available_bytes = total_available_bytes
-        grouped_param_keys, keys = [], []
+        grouped_param_keys: list[list[str]] = []
+        keys: list[str] = []
 
-        for key, tensor in self._held_sharded_state_dict_reference.items():
+        for key, tensor in self._held_sharded_state_dict_reference.items():  # type: ignore
             # dtensor's numel will return complete tensor instead of only local tensor
             size_in_bytes = tensor.element_size() * tensor.numel()
 

--- a/nemo_rl/models/policy/hf_policy.py
+++ b/nemo_rl/models/policy/hf_policy.py
@@ -338,17 +338,18 @@ class HfPolicy(ColocatablePolicyInterface, GenerationInterface):
         # Placeholder implementation
         pass
 
-    def prepare_weights_for_ipc(self) -> list[tuple[str, int]]:
+    def prepare_weights_for_ipc(self, refit_buffer_size_gb: int = None) -> list[list[str]]:
         """Prepare the weights for IPC.
 
         Returns:
-            dict: A dictionary containing the state_dict_info of the model.
+            list: A list containing the keys of the parameters, which is grouped by size.
         """
         futures = self.worker_group.run_all_workers_single_data(
-            "prepare_weights_for_ipc"
+            "prepare_weights_for_ipc",
+            refit_buffer_size_gb,
         )
         # only get the first worker's result is enough since all workers will have the same result
-        return cast(list[tuple[str, int]], ray.get(futures)[0])
+        return cast(list[list[str]], ray.get(futures)[0])
 
     def get_weights_ipc_handles(self, keys: list[str]) -> dict[str, Any]:
         """Fetch weight IPC handles from all workers.

--- a/nemo_rl/models/policy/hf_policy.py
+++ b/nemo_rl/models/policy/hf_policy.py
@@ -338,7 +338,9 @@ class HfPolicy(ColocatablePolicyInterface, GenerationInterface):
         # Placeholder implementation
         pass
 
-    def prepare_weights_for_ipc(self, refit_buffer_size_gb: int = None) -> list[list[str]]:
+    def prepare_weights_for_ipc(
+        self, refit_buffer_size_gb: Optional[int] = None
+    ) -> list[list[str]]:
         """Prepare the weights for IPC.
 
         Returns:

--- a/nemo_rl/models/policy/hf_policy.py
+++ b/nemo_rl/models/policy/hf_policy.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import os
 from collections import defaultdict
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 import numpy as np
 import ray
@@ -339,19 +339,47 @@ class HfPolicy(ColocatablePolicyInterface, GenerationInterface):
         pass
 
     def prepare_weights_for_ipc(
-        self, refit_buffer_size_gb: Optional[int] = None
+        self, _refit_buffer_size_gb: Optional[int] = None
     ) -> list[list[str]]:
         """Prepare the weights for IPC.
 
         Returns:
             list: A list containing the keys of the parameters, which is grouped by size.
         """
+        # Get the state_dict_info and available memory from all workers
         futures = self.worker_group.run_all_workers_single_data(
-            "prepare_weights_for_ipc",
-            refit_buffer_size_gb,
+            "prepare_weights_for_ipc"
         )
-        # only get the first worker's result is enough since all workers will have the same result
-        return cast(list[list[str]], ray.get(futures)[0])
+        results = ray.get(futures)
+
+        # Only get the first worker's state_dict_info since all workers will have the same result
+        state_dict_info = results[0][0]
+
+        if _refit_buffer_size_gb is not None:
+            total_available_bytes = _refit_buffer_size_gb * (1024**3)
+        else:
+            # Get the minimum available memory from all workers
+            total_available_bytes = min(result[1] for result in results)
+
+        # Group tensors by size
+        cur_available_bytes = total_available_bytes
+        grouped_param_keys: list[list[str]] = []
+        keys: list[str] = []
+
+        for key, size_in_bytes in state_dict_info:
+            if size_in_bytes > cur_available_bytes:
+                if keys:
+                    grouped_param_keys.append(keys)
+                    keys = []
+                cur_available_bytes = total_available_bytes
+
+            keys.append(key)
+            cur_available_bytes -= size_in_bytes
+
+        if keys:
+            grouped_param_keys.append(keys)
+
+        return grouped_param_keys
 
     def get_weights_ipc_handles(self, keys: list[str]) -> dict[str, Any]:
         """Fetch weight IPC handles from all workers.

--- a/nemo_rl/models/policy/interfaces.py
+++ b/nemo_rl/models/policy/interfaces.py
@@ -102,9 +102,7 @@ class ColocatablePolicyInterface(PolicyInterface):
         pass
 
     @abstractmethod
-    def prepare_weights_for_ipc(
-        self, *args: Any, **kwargs: Any
-    ) -> list[tuple[str, int]]:
+    def prepare_weights_for_ipc(self, *args: Any, **kwargs: Any) -> list[list[str]]:
         pass
 
     @abstractmethod

--- a/nemo_rl/utils/nvml.py
+++ b/nemo_rl/utils/nvml.py
@@ -75,3 +75,16 @@ def get_device_uuid(device_idx: int) -> str:
             raise RuntimeError(
                 f"Failed to get device UUID for device {device_idx} (global index: {global_device_idx}): {e}"
             )
+
+
+def get_free_memory_bytes(device_idx: int) -> float:
+    """Get the free memory of a CUDA device in bytes using NVML."""
+    global_device_idx = device_id_to_physical_device_id(device_idx)
+    with nvml_context():
+        try:
+            handle = pynvml.nvmlDeviceGetHandleByIndex(global_device_idx)
+            return pynvml.nvmlDeviceGetMemoryInfo(handle).free
+        except pynvml.NVMLError as e:
+            raise RuntimeError(
+                f"Failed to get free memory for device {device_idx} (global index: {global_device_idx}): {e}"
+            )

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -843,9 +843,9 @@ def test_vllm_weight_update_and_prefix_cache_reset(
         )
 
         print("Updating vLLM weights from HF policy...")
-        param_keys = hf_policy.prepare_weights_for_ipc()
-        for key, _ in param_keys:
-            ipc_handles = hf_policy.get_weights_ipc_handles([key])
+        grouped_param_keys = hf_policy.prepare_weights_for_ipc()
+        for keys in grouped_param_keys:
+            ipc_handles = hf_policy.get_weights_ipc_handles(keys)
             update_success = vllm_policy.update_weights(ipc_handles)
             assert update_success, "Weight update should succeed"
         print("vLLM weights successfully updated.")

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -311,10 +311,7 @@ async def test_vllm_policy_generation_async(
         print("creating hf policy...")
 
         hf_policy = HfPolicy(cluster, hf_config, tokenizer)
-
-        refit_policy_generation(
-            hf_policy, async_policy, hf_config["refit_buffer_size_gb"]
-        )
+        refit_policy_generation(hf_policy, async_policy)
 
         outputs = async_policy.generate_async(test_input_data)
         # Validate outputs format

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -75,7 +75,6 @@ def get_basic_hf_test_config(enable_dtensor: bool = False) -> PolicyConfig:
         "precision": "float32",
         "fsdp_offload_enabled": False,
         "activation_checkpointing_enabled": False,
-        "refit_buffer_size_gb": 4,
         "optimizer": {
             "name": "torch.optim.AdamW",
             "kwargs": {
@@ -410,7 +409,7 @@ def test_vllm_worker_seed_behavior(cluster, tokenizer):
     hf_policy = HfPolicy(cluster, hf_config, tokenizer)
 
     print("refitting vllm policy...")
-    refit_policy_generation(hf_policy, policy, hf_config["refit_buffer_size_gb"])
+    refit_policy_generation(hf_policy, policy)
 
     try:
         # Generate with duplicated prompts
@@ -566,9 +565,7 @@ def test_vllm_generation_with_hf_training(
         hf_policy = HfPolicy(cluster, hf_config, tokenizer)
 
         print("refitting vllm policy...")
-        refit_policy_generation(
-            hf_policy, vllm_policy, hf_config["refit_buffer_size_gb"]
-        )
+        refit_policy_generation(hf_policy, vllm_policy)
 
         # Step 1: Use vLLM for generation
         print("Using vLLM policy for fast generation...")
@@ -987,11 +984,7 @@ def test_vllm_generation_with_stop(
         hf_policy = HfPolicy(cluster, hf_config, tokenizer)
 
         print("refitting vllm policy...")
-        refit_policy_generation(
-            hf_policy,
-            vllm_generation,
-            hf_config["refit_buffer_size_gb"],
-        )
+        refit_policy_generation(hf_policy, vllm_generation)
 
     # test generate
     outputs = vllm_generation.generate(test_input_data, greedy=True)
@@ -1095,7 +1088,6 @@ def test_vllm_refit_non_collocated_handles_update_failure(
                 refit_policy_generation(
                     hf_policy_instance,
                     vllm_policy_instance,
-                    hf_config["refit_buffer_size_gb"],
                 )
         print("RuntimeError during refit correctly caught.")
 

--- a/tests/unit/models/generation/test_vllm_generation.py
+++ b/tests/unit/models/generation/test_vllm_generation.py
@@ -914,7 +914,7 @@ def test_vllm_weight_update_memory(cluster, tokenizer, enable_dtensor):
     # reset peak memory stats before refit
     workers = hf_policy.worker_group.workers
     ray.get([w.reset_peak_memory_stats.remote() for w in workers])
-    refit_policy_generation(hf_policy, vllm_policy, refit_buffer_size_gb=1)
+    refit_policy_generation(hf_policy, vllm_policy, _refit_buffer_size_gb=1)
     gpu_infos = ray.get([w.get_gpu_info.remote() for w in workers])
 
     # Gather memory stats


### PR DESCRIPTION
# What does this PR do ?

Compute `refit_buffer_size_gb` by remaining memory at refitting process instead of manually set it.

I kept `refit_buffer_size_gb` param at `refit_policy_generation()` and `prepare_weights_for_ipc()` only for unit test, and removed it at any other places.


# Issues
Closes https://github.com/NVIDIA/nemo-rl/issues/249


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/nemo-rl/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/nemo-rl/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/nemo-rl/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
