### PR TITLE
fix: Make dtensor default in 8b config

### DIFF
--- a/examples/configs/grpo_math_8B.yaml
+++ b/examples/configs/grpo_math_8B.yaml
@@ -20,7 +20,7 @@ policy:
   refit_buffer_size_gb: 4 # used for refitting inference engine, the unit is GB
 
   dtensor_cfg:
-    enabled: False
+    enabled: True
 
   dynamic_batching:
     train_mb_tokens: 4096


### PR DESCRIPTION
Make dtensor default in 8b config; fixes broken example in README fo multinode

# What does this PR do ?

README example for multinode was broken:
```    
assert config["dtensor_cfg"]["enabled"], (           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
AssertionError: Dynamic batch is only supported for DTensor policy.
```

**Add a one line overview of what this PR aims to accomplish.**

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
