### PR TITLE
fix: enable dashboard on local clusters

### DIFF
--- a/nemo_rl/distributed/virtual_cluster.py
+++ b/nemo_rl/distributed/virtual_cluster.py
@@ -139,7 +139,7 @@ def init_ray(log_dir: Optional[str] = None):
 
     ray.init(
         log_to_driver=True,
-        include_dashboard=False,
+        include_dashboard=True,
         runtime_env=local_runtime_env,
         _temp_dir=os.path.abspath(log_dir) if log_dir else None,
         resources={cvd_tag: 1},


### PR DESCRIPTION
This is okay to do for all local clusters b/c ray's default behavior is to find another port if the current one is taken. It's up to the user to look up the port in the logs to see which port to attach the debugger to (or to open the dashboard)

@gshennvm 