### PR TITLE
docs: Added a small pointer doc to the docker dir to prevent confusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,9 @@ hf_home/
 hf_datasets_cache/
 *logs/
 datasets/
-docker/
+docker/*
+!docker/Dockerfile
+!docker/README.md
 wandb/
 checkpoints/
 results/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,10 @@
+# Building the Docker Container
+NOTE: *We use `docker buildx` instead of `docker build` for these containers*
+
+This directory contains the `Dockerfile` for NeMo-RL Docker images.
+You can build two types of images:
+- A **base image**: A minimal image where Python dependencies can be specified at runtime.
+- A **hermetic image**: An image that includes default dependencies for offline use.
+
+
+For detailed instructions on building these images, please see [docs/docker.md](../docs/docker.md).


### PR DESCRIPTION
People aren't necessarily seeing the docker documentation page in our documentation, so I added a small README to the docker/ dir to point to it. Also, .gitignore was ignoring the Dockerfile, so I fixed that as well.