### PR TITLE
cp: `ci: Update cherry-pick workflow to pass semantic PR check (#414)` into `r0.2.1`

### DIFF
--- a/.github/workflows/cherry-pick-release-commit.yml
+++ b/.github/workflows/cherry-pick-release-commit.yml
@@ -13,14 +13,14 @@
 # limitations under the License.
 name: Create PR to main with cherry-pick from release
 
-on: 
+on:
   push:
     branches:
       - main
 
 jobs:
   cherry-pick:
-    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_cherry_pick.yml@v0.22.7
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_cherry_pick.yml@v0.31.0
     secrets:
       PAT: ${{ secrets.PAT }}
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -36,5 +36,4 @@ permissions:
 
 jobs:
   semantic-pull-request:
-    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_semantic_pull_request.yml@v0.13.0
-    
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_semantic_pull_request.yml@v0.31.0


### PR DESCRIPTION
# What does this PR do ?

cp: `ci: Update cherry-pick workflow to pass semantic PR check (#414)` into `r0.2.1`

This aims to resolve the semantic PR failure on the release branch.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
