### PR TITLE
ci: Set codecov override_branch to main if from merge queue

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -236,7 +236,7 @@ jobs:
           file: ./coverage.json
           flags: unit-tests
           verbose: true
-          override_branch	: ${{ github.event_name == 'merge_group' && 'main' || '' }}
+          override_branch: ${{ github.event_name == 'merge_group' && 'main' || '' }}
 
   CI_QA_Gate:
     name: CI quality check

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -115,7 +115,7 @@ jobs:
           pip install pre-commit
           pre-commit install
           pre-commit run --all-files --show-diff-on-failure --color=always
-  
+
   mypy-check:
     name: Mypy check
     needs: [pre-flight]
@@ -236,6 +236,7 @@ jobs:
           file: ./coverage.json
           flags: unit-tests
           verbose: true
+          override_branch	: ${{ github.event_name == 'merge_group' && 'main' || '' }}
 
   CI_QA_Gate:
     name: CI quality check


### PR DESCRIPTION
# What does this PR do ?

Set codecov override_branch to main if from merge queue. 

The codecov upload works, but when it's ran during a merge queue, it uses the temporary branch as the name.  We should just set this to 'main'.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
