### PR TITLE
ci: Update release workflow to optionally release pypi without github release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,37 +14,38 @@
 name: "Release NeMo-RL"
 
 on:
-  workflow_dispatch:
-    inputs:
-      release-ref:
-        description: Ref (SHA or branch name) to release
-        required: true
-        type: string
-      dry-run:
-        description: Do not publish a wheel and GitHub release.
-        required: true
-        default: true
-        type: boolean
-      create-gh-release:
-        description: Create a GitHub release
-        required: true
-        default: true
-        type: boolean
-      version-bump-branch:
-        description: Branch for version bump
-        required: true
-        type: string
+  push:
+  # workflow_dispatch:
+  #   inputs:
+  #     release-ref:
+  #       description: Ref (SHA or branch name) to release
+  #       required: true
+  #       type: string
+  #     dry-run:
+  #       description: Do not publish a wheel and GitHub release.
+  #       required: true
+  #       default: true
+  #       type: boolean
+  #     create-gh-release:
+  #       description: Create a GitHub release
+  #       required: true
+  #       default: true
+  #       type: boolean
+  #     version-bump-branch:
+  #       description: Branch for version bump
+  #       required: true
+  #       type: string
 
 jobs:
   release:
     uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@416183f500df51ab5ef4b9c7cb06275721bdfc92
     with:
-      release-ref: ${{ inputs.release-ref }}
+      release-ref: ${{ github.sha }}
       python-package: nemo_rl
       library-name: NeMo-RL
-      dry-run: ${{ inputs.dry-run }}
-      version-bump-branch: ${{ inputs.version-bump-branch }}
-      create-gh-release: ${{ inputs.create-gh-release }}
+      dry-run: true
+      version-bump-branch: chtruong/release-pypi-only
+      create-gh-release: false
       packaging: uv
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,38 +14,37 @@
 name: "Release NeMo-RL"
 
 on:
-  push:
-  # workflow_dispatch:
-  #   inputs:
-  #     release-ref:
-  #       description: Ref (SHA or branch name) to release
-  #       required: true
-  #       type: string
-  #     dry-run:
-  #       description: Do not publish a wheel and GitHub release.
-  #       required: true
-  #       default: true
-  #       type: boolean
-  #     create-gh-release:
-  #       description: Create a GitHub release
-  #       required: true
-  #       default: true
-  #       type: boolean
-  #     version-bump-branch:
-  #       description: Branch for version bump
-  #       required: true
-  #       type: string
+  workflow_dispatch:
+    inputs:
+      release-ref:
+        description: Ref (SHA or branch name) to release
+        required: true
+        type: string
+      dry-run:
+        description: Do not publish a wheel and GitHub release.
+        required: true
+        default: true
+        type: boolean
+      create-gh-release:
+        description: Create a GitHub release
+        required: true
+        default: true
+        type: boolean
+      version-bump-branch:
+        description: Branch for version bump
+        required: true
+        type: string
 
 jobs:
   release:
     uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@416183f500df51ab5ef4b9c7cb06275721bdfc92
     with:
-      release-ref: ${{ github.sha }}
+      release-ref: ${{ inputs.release-ref }}
       python-package: nemo_rl
       library-name: NeMo-RL
-      dry-run: true
-      version-bump-branch: chtruong/release-pypi-only
-      create-gh-release: false
+      dry-run: ${{ inputs.dry-run }}
+      version-bump-branch: ${{ inputs.version-bump-branch }}
+      create-gh-release: ${{ inputs.create-gh-release }}
       packaging: uv
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   release:
-    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@416183f500df51ab5ef4b9c7cb06275721bdfc92
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@v0.34.0
     with:
       release-ref: ${{ inputs.release-ref }}
       python-package: nemo_rl

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,11 @@ on:
         required: true
         default: true
         type: boolean
+      create-gh-release:
+        description: Create a GitHub release
+        required: true
+        default: true
+        type: boolean
       version-bump-branch:
         description: Branch for version bump
         required: true
@@ -32,13 +37,14 @@ on:
 
 jobs:
   release:
-    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@v0.33.0
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@416183f500df51ab5ef4b9c7cb06275721bdfc92
     with:
       release-ref: ${{ inputs.release-ref }}
       python-package: nemo_rl
       library-name: NeMo-RL
       dry-run: ${{ inputs.dry-run }}
       version-bump-branch: ${{ inputs.version-bump-branch }}
+      create-gh-release: ${{ inputs.create-gh-release }}
       packaging: uv
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}


### PR DESCRIPTION
# What does this PR do ?

Update release workflow to optionally release pypi without github release.

Afer this merges, we will attempt to push the package for the existing release 0.2.1.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
