### PR TITLE
fix: [FSDP2] reshard_after_forward=False for root model

### DIFF
--- a/nemo_rl/models/dtensor/parallelize.py
+++ b/nemo_rl/models/dtensor/parallelize.py
@@ -485,6 +485,8 @@ def _parallelize_model(
             layer, mesh=dp_mesh, mp_policy=mp_policy, offload_policy=offload_policy
         )
 
+    # do not reshard after forward for root model
+    # because its parameters will be used in backward immediately
     return fully_shard(
         model,
         mesh=dp_mesh,

--- a/nemo_rl/models/dtensor/parallelize.py
+++ b/nemo_rl/models/dtensor/parallelize.py
@@ -486,7 +486,11 @@ def _parallelize_model(
         )
 
     return fully_shard(
-        model, mesh=dp_mesh, mp_policy=mp_policy, offload_policy=offload_policy
+        model,
+        mesh=dp_mesh,
+        mp_policy=mp_policy,
+        offload_policy=offload_policy,
+        reshard_after_forward=False,
     )
 
 


### PR DESCRIPTION
# What does this PR do ?

Hi from pytorch fsdp2! set `fully_shard(reshard_after_forward=False)` to keep the memory behavior the same after pytorch side change: https://github.com/pytorch/pytorch/pull/154704

for root model, `reshard_after_forward=False` means keep root parameters unsharded after forward, since they will be used in the backward immeidately. This is a AA change

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

# Usage
* **You can potentially add a usage example below**

```python
uv run python examples/run_grpo_math.py cluster.gpus_per_node=8
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
