### PR TITLE
Fix printing validation results in GRPO

### DIFF
--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -674,10 +674,14 @@ def validate(
             total_lengths.append(gen_metrics["mean_gen_tokens_per_sample"])
 
             # Collect message logs for later display
-            to_env = get_keys_from_message_log(
-                val_batch["message_log"], ["role", "content"]
-            )
-            all_message_logs.append(to_env)
+            to_env = [
+                get_keys_from_message_log(
+                    val_batch["message_log"][i], ["role", "content"]
+                )
+                for i in range(len(val_batch["message_log"]))
+            ]
+
+            all_message_logs.extend(to_env)
 
         # Calculate validation metrics
         accuracy = sum(total_rewards) / len(total_rewards)


### PR DESCRIPTION
# What does this PR do ?

Fix printing validation results in GRPO (before, it'd say `Error displaying message samples: Message logs and rewards must have the same length.

# Issues
[main issue](https://github.com/NVIDIA/NeMo-RL/issues/469)


# Usage
* **You can potentially add a usage example below**
Example:
` uv run examples/run_grpo_math.py --config=examples/configs/grpo_math_1B.yaml logger.logger.num_val_samples_to_print=20` 

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
This just brings `grpo.py` in line with all other places that use `get_keys_from_message_log` on batches, like `nemo_rl/experience/rollouts.py` and `nemo_rl/evals/eval.py`
