### PR TITLE
fix: async rollouts; incorrect tokens generated

### DIFF
--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -61,7 +61,10 @@ def generate_responses(
         generation_input_data["stop_strings"] = [None] * len(input_lengths)
 
     # Generate responses
-    if policy_generation.cfg["vllm_cfg"]["async_engine"]:
+    if (
+        "vllm_cfg" in policy_generation.cfg
+        and policy_generation.cfg["vllm_cfg"]["async_engine"]
+    ):
         generation_outputs = policy_generation.generate_async(
             generation_input_data, greedy=greedy
         )

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -61,9 +61,14 @@ def generate_responses(
         generation_input_data["stop_strings"] = [None] * len(input_lengths)
 
     # Generate responses
-    generation_outputs = policy_generation.generate(
-        generation_input_data, greedy=greedy
-    )
+    if policy_generation.cfg["vllm_cfg"]["async_engine"]:
+        generation_outputs = policy_generation.generate_async(
+            generation_input_data, greedy=greedy
+        )
+    else:
+        generation_outputs = policy_generation.generate(
+            generation_input_data, greedy=greedy
+        )
 
     # Extract generated tokens
     generated_ids = []

--- a/nemo_rl/models/generation/vllm.py
+++ b/nemo_rl/models/generation/vllm.py
@@ -274,17 +274,27 @@ class VllmGenerationWorker:
 
         return list(stop_set) if stop_set else None
 
-    def _build_sampling_params(self, *, greedy: bool, stop_strings):
+    def _build_sampling_params(
+        self,
+        *,
+        greedy: bool,
+        stop_strings,
+        max_new_tokens: Optional[int] = None,
+    ):
         top_k_cfg = self.cfg["top_k"]
         top_k_val = 1 if greedy else (top_k_cfg if top_k_cfg is not None else -1)
 
         temperature = 0.0 if greedy else self.cfg["temperature"]
 
+        max_tokens = (
+            max_new_tokens if max_new_tokens is not None else self.cfg["max_new_tokens"]
+        )
+
         return self.SamplingParams(
             temperature=temperature,
             top_p=self.cfg["top_p"],
             top_k=top_k_val,
-            max_tokens=self.cfg["max_new_tokens"],
+            max_tokens=max_tokens,
             logprobs=0,
             stop_token_ids=self.cfg["stop_token_ids"],
             stop=stop_strings,
@@ -491,9 +501,15 @@ class VllmGenerationWorker:
                 [per_sample_stop_strings] if per_sample_stop_strings else None
             )
 
+            remaining_ctx = (
+                self.cfg["vllm_cfg"]["max_model_len"] - current_input_actual_length
+            )
+            allowed_new_tokens = max(0, min(self.cfg["max_new_tokens"], remaining_ctx))
+
             sampling_params_for_request = self._build_sampling_params(
                 greedy=greedy,
                 stop_strings=final_stop_strings_for_sample,
+                max_new_tokens=allowed_new_tokens,
             )
 
             request_id = str(uuid.uuid4())
@@ -536,11 +552,8 @@ class VllmGenerationWorker:
             generated_token_ids = list(generation_details.token_ids)
             num_generated_tokens = len(generated_token_ids)
 
-            original_padded_len_of_this_input_row = original_input_ids_single_row.shape[
-                0
-            ]
             final_output_tensor_len = (
-                original_padded_len_of_this_input_row + num_generated_tokens
+                original_input_actual_length + num_generated_tokens
             )
 
             # Create output_ids tensor for this single item


### PR DESCRIPTION

# What does this PR do ?

1. Allow rollouts to use async generate.
2. Fix async generate sampling params to allow only the required number of tokens to be generated.

# Issues
List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):


# Usage
* **You can potentially add a usage example below**

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](/NVIDIA/NeMo-RL/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you run the unit tests and functional tests locally? Visit our [Testing Guide](/NVIDIA/NeMo-RL/blob/main/docs/testing.md) for how to run tests
- [ ] Did you add or update any necessary documentation? Visit our [Document Development Guide](/NVIDIA/NeMo-RL/blob/main/docs/documentation.md) for how to write, build and test the docs.

# Additional Information
* ...
