### PR TITLE
fix: add more checks for seq len as well as a script to check `max_model_len`

### DIFF
--- a/docs/adding-new-models.md
+++ b/docs/adding-new-models.md
@@ -128,7 +128,7 @@ By following these validation steps and ensuring your model's outputs remain con
 We also maintain a set of standalone scripts that can be used to diagnose issues related to correctness that
 we have encountered before.
 
-## [1.max_model_len_respected.py](../tools/model_diagnostics/1.max_model_len_respected.py)
+## [1.max_model_len_respected.py](https://github.com/NVIDIA/NeMo-RL/blob/main/tools/model_diagnostics/1.max_model_len_respected.py)
 
 Tests if a new model respects the `max_model_len` passed to vllm
 

--- a/docs/adding-new-models.md
+++ b/docs/adding-new-models.md
@@ -1,5 +1,17 @@
 # Add New Models
 
+- [Add New Models](#add-new-models)
+  - [Importance of Log Probability Consistency in Training and Inference](#importance-of-log-probability-consistency-in-training-and-inference)
+  - [Understand Discrepancies Between Backends](#understand-discrepancies-between-backends)
+  - [1. Hugging Face–Based Models](#1-hugging-facebased-models)
+    - [Validation Workflow](#validation-workflow)
+  - [2. Megatron Models](#2-megatron-models)
+    - [Additional Validation](#additional-validation)
+  - [3. Expected Error Threshold](#3-expected-error-threshold)
+- [Model Diagnostics](#model-diagnostics)
+  - [1.max\_model\_len\_respected.py](#1max_model_len_respectedpy)
+
+
 This guide outlines how to integrate and validate a new model within NeMo RL. Each new model must pass a standard set of compatibility tests before being considered ready to be used in RL pipelines.
 
 ## Importance of Log Probability Consistency in Training and Inference
@@ -121,3 +133,23 @@ When validating your model, you should analyze the results across different conf
 ---
 
 By following these validation steps and ensuring your model's outputs remain consistent across backends, you can confirm that your new model meets the requirements of NeMo RL.
+
+
+# Model Diagnostics
+
+We also maintain a set of standalone scripts that can be used to diagnose issues related to correctness that
+we have encountered before.
+
+## [1.max_model_len_respected.py](../tools/model_diagnostics/1.max_model_len_respected.py)
+
+Tests if a new model respects the `max_model_len` passed to vllm
+
+```sh
+# Run that is expected to pass
+uv run --extra vllm tools/model_diagnostics/1.max_model_len_respected.py Qwen/Qwen2.5-1.5B
+# ...
+# Prompt tokens: 8
+# Generated tokens: 12
+# Total tokens: 20
+# [Qwen/Qwen2.5-1.5B] ALL GOOD!
+```

--- a/docs/adding-new-models.md
+++ b/docs/adding-new-models.md
@@ -130,7 +130,7 @@ we have encountered before.
 
 ## [1.max_model_len_respected.py](https://github.com/NVIDIA/NeMo-RL/blob/main/tools/model_diagnostics/1.max_model_len_respected.py)
 
-Tests if a new model respects the `max_model_len` passed to vllm
+Test if a new model respects the `max_model_len` passed to vllm:
 
 ```sh
 # Run that is expected to pass

--- a/docs/adding-new-models.md
+++ b/docs/adding-new-models.md
@@ -1,18 +1,6 @@
 # Add New Models
 
-- [Add New Models](#add-new-models)
-  - [Importance of Log Probability Consistency in Training and Inference](#importance-of-log-probability-consistency-in-training-and-inference)
-  - [Understand Discrepancies Between Backends](#understand-discrepancies-between-backends)
-  - [1. Hugging Face–Based Models](#1-hugging-facebased-models)
-    - [Validation Workflow](#validation-workflow)
-  - [2. Megatron Models](#2-megatron-models)
-    - [Additional Validation](#additional-validation)
-  - [3. Expected Error Threshold](#3-expected-error-threshold)
-- [Model Diagnostics](#model-diagnostics)
-  - [1.max\_model\_len\_respected.py](#1max_model_len_respectedpy)
-
-
-This guide outlines how to integrate and validate a new model within NeMo RL. Each new model must pass a standard set of compatibility tests before being considered ready to be used in RL pipelines.
+This guide outlines how to integrate and validate a new model within NeMo RL. Each new model must pass a standard set of compatibility tests before being considered ready to be used in RL pipelines. The guide also details diagnostic scripts to help identify and resolve common issues during model integration.
 
 ## Importance of Log Probability Consistency in Training and Inference
 

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -61,9 +61,17 @@ def generate_responses(
         generation_input_data["stop_strings"] = [None] * len(input_lengths)
 
     # Generate responses
-    generation_outputs = policy_generation.generate(
-        generation_input_data, greedy=greedy
-    )
+    if (
+        "vllm_cfg" in policy_generation.cfg
+        and policy_generation.cfg["vllm_cfg"]["async_engine"]
+    ):
+        generation_outputs = policy_generation.generate_async(
+            generation_input_data, greedy=greedy
+        )
+    else:
+        generation_outputs = policy_generation.generate(
+            generation_input_data, greedy=greedy
+        )
 
     # Extract generated tokens
     generated_ids = []

--- a/nemo_rl/experience/rollouts.py
+++ b/nemo_rl/experience/rollouts.py
@@ -61,17 +61,9 @@ def generate_responses(
         generation_input_data["stop_strings"] = [None] * len(input_lengths)
 
     # Generate responses
-    if (
-        "vllm_cfg" in policy_generation.cfg
-        and policy_generation.cfg["vllm_cfg"]["async_engine"]
-    ):
-        generation_outputs = policy_generation.generate_async(
-            generation_input_data, greedy=greedy
-        )
-    else:
-        generation_outputs = policy_generation.generate(
-            generation_input_data, greedy=greedy
-        )
+    generation_outputs = policy_generation.generate(
+        generation_input_data, greedy=greedy
+    )
 
     # Extract generated tokens
     generated_ids = []
@@ -321,10 +313,14 @@ def run_multi_turn_rollout(
                 len(tokenized_obs) + len(generated_ids[i]) + active_input_lengths[i]
                 >= max_seq_len
             ):
+                tokens_left_for_obs = max_seq_len - (
+                    len(generated_ids[i]) + active_input_lengths[i]
+                )
+                assert tokens_left_for_obs >= 0, (
+                    f"tokens_left_for_obs={tokens_left_for_obs} should not be negative. This should not happen if the inference engine respects the max sequence length."
+                )
                 # truncate
-                tokenized_obs = tokenized_obs[
-                    : max_seq_len - (len(generated_ids[i]) + active_input_lengths[i])
-                ]
+                tokenized_obs = tokenized_obs[:tokens_left_for_obs]
                 truncation_mask[i] = True
                 # Record truncation
                 sample_truncated[active_indices[i]] = True

--- a/nemo_rl/models/generation/vllm.py
+++ b/nemo_rl/models/generation/vllm.py
@@ -416,6 +416,9 @@ class VllmGenerationWorker:
             response_length = sequence_length + len(generated_tokens)
             generation_lengths.append(len(generated_tokens))
             unpadded_sequence_lengths.append(response_length)
+            assert response_length != self.llm.llm_engine.model_config.max_model_len, (
+                f"response_length={response_length} > max_model_len={self.llm.llm_engine.model_config.max_model_len}, which should not happen. Please check this behavior in isolation by running `uv run --extra vllm tools/model_diagnostics/1.max_model_len_respected.py {self.llm.llm_engine.model_config.model}` and raise this issue with the vllm team."
+            )
         # Create return data conforming to GenerationOutputSpec
         output_ids = torch.stack(output_ids_list)
         logprobs = torch.stack(logprobs_list)

--- a/nemo_rl/models/generation/vllm.py
+++ b/nemo_rl/models/generation/vllm.py
@@ -416,7 +416,7 @@ class VllmGenerationWorker:
             response_length = sequence_length + len(generated_tokens)
             generation_lengths.append(len(generated_tokens))
             unpadded_sequence_lengths.append(response_length)
-            assert response_length != self.llm.llm_engine.model_config.max_model_len, (
+            assert response_length <= self.llm.llm_engine.model_config.max_model_len, (
                 f"response_length={response_length} > max_model_len={self.llm.llm_engine.model_config.max_model_len}, which should not happen. Please check this behavior in isolation by running `uv run --extra vllm tools/model_diagnostics/1.max_model_len_respected.py {self.llm.llm_engine.model_config.model}` and raise this issue with the vllm team."
             )
         # Create return data conforming to GenerationOutputSpec

--- a/tools/model_diagnostics/1.max_model_len_respected.py
+++ b/tools/model_diagnostics/1.max_model_len_respected.py
@@ -1,0 +1,36 @@
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("model", type=str, nargs="?", default="ibm-ai-platform/Bamba-9B-v1")
+args = parser.parse_args()
+
+
+from vllm import LLM, SamplingParams
+
+llm = LLM(
+    # Examples as of 0.9.0
+    # model="facebook/opt-125m", # ok: 20
+    # model="meta-llama/Llama-3.1-8B-Instruct", # ok: 20
+    # model="meta-llama/Meta-Llama-3-8B", # ok: 20
+    # model="nvidia/Nemotron-H-8B-Base-8K", # not good: 21
+    # model="ibm-ai-platform/Bamba-9B-v1",  # not good: 21
+    model=args.model,
+    max_model_len=20,  # total tokens = prompt + generated
+    trust_remote_code=True,
+)
+prompt = "Hello, this is a test prompt."
+sampling_params = SamplingParams(max_tokens=20)
+output = llm.generate([prompt], sampling_params)[0]
+
+num_prompt_tokens = len(output.prompt_token_ids)
+num_generated_tokens = len(output.outputs[0].token_ids)
+num_total_tokens = num_prompt_tokens + num_generated_tokens
+
+print(f"Prompt tokens: {num_prompt_tokens}")
+print(f"Generated tokens: {num_generated_tokens}")
+print(f"Total tokens: {num_total_tokens}")
+
+assert num_total_tokens <= llm.llm_engine.model_config.max_model_len, (
+    f"num_total_tokens={num_total_tokens} > max_model_len={llm.llm_engine.model_config.max_model_len} for model={args.model}, which should not happen."
+)
+print(f"[{args.model}] ALL GOOD!")

--- a/tools/model_diagnostics/1.max_model_len_respected.py
+++ b/tools/model_diagnostics/1.max_model_len_respected.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import argparse
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
Example failure:

```
uv run --extra vllm tools/model_diagnostics/1.max_model_len_respected.py
...
Processed prompts: 100%|███████████| 1/1 [00:00<00:00,  2.15it/s, est. speed input: 19.34 toks/s, output: 25.79 toks/s]
Prompt tokens: 9
Generated tokens: 12
Total tokens: 21
[rank0]: Traceback (most recent call last):
[rank0]:   File "/lustre/fsw/portfolios/coreai/users/terryk/rewrite-aligner/reinforcer/tools/model_diagnostics/1.max_model_len_respected.py", line 34, in <module>
[rank0]:     assert num_total_tokens <= llm.llm_engine.model_config.max_model_len, f"num_total_tokens={num_total_tokens} > max_model_len={llm.llm_engine.model_config.max_model_len} for model={args.model}, which should not happen."
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: AssertionError: num_total_tokens=21 > max_model_len=20 for model=ibm-ai-platform/Bamba-9B-v1, which should not happen.
```

Example success:
```
uv run --extra vllm tools/model_diagnostics/1.max_model_len_respected.py Qwen/Qwen2.5-1.5B
...
Adding requests: 100%|██████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 145.52it/s]
Processed prompts: 100%|█████████| 1/1 [00:00<00:00, 24.21it/s, est. speed input: 193.88 toks/s, output: 290.73 toks/s]
Prompt tokens: 8
Generated tokens: 12
Total tokens: 20
[Qwen/Qwen2.5-1.5B] ALL GOOD!
```

Related to #2 